### PR TITLE
Rename product as shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,35 @@ pipeline.shift #=> 'westward'
 pipeline.shift #=> nil
 ```
 
+### Trailing Worker
+
+
+The trailing worker accepts a value, and returns an array containing the
+last _n_ values.  This worker could be useful for things like rolling averages.
+
+No values are returned until n values had been accumulated. New values are
+_unshifted_ into the zero-th position in the array of trailing values, so
+that a given value will graduate through the array until it reaches the last
+position and then subsequently removed.
+
+Maybe it's easiest to just give an example:
+
+```ruby
+source = source_worker (0..5)
+trailer = trailing_worker 4
+
+pipeline = source | trailer
+
+pipeline.shift #=> [3,2,1,0]
+pipeline.shift #=> [4,3,2,1]
+pipeline.shift #=> [5,4,3,2]
+pipeline.shift #=> nil
+```
+
+Note that as soon as a nil is received from the supplying queue, the trailing
+worker simply provides a nil.
+
+
 ## Origins of Stepladder
 
 Stepladder grew out of experimentation with Ruby fibers, after readings
@@ -388,10 +417,6 @@ The Stepladder::Worker documentation has been moved
 
 ## Roadmap
 
-- `rolling_worker trails: n` -- accepts a value, and returns the last n
-  values.  This would mean that no values would be returned until n
-  values had been accumulated.  This could be useful for things like
-  rolling averages.
 - `side_worker(:hardened) { |v| do_stuff_with(v) }` -- the `:hardened`
   flag would attempt to ensure no side effects may occur by using
   `Marshal` to dump/load the value before handing it to the workers

--- a/README.md
+++ b/README.md
@@ -248,6 +248,30 @@ pipeline.shift #=> ["fall", "but", "ok"]
 pipeline.shift #=> nil
 ```
 
+### Splitter Worker
+
+The splitter worker accepts a value from its supply, and generates an array
+and then successively returns each element of the array.  Once the array
+has been expended, the splitter worker appeals to its supplier for another
+value and the process repeats.
+
+```ruby
+source = source_worker [
+  'A bold', 'move westward' ]
+
+splitter = splitter_worker do |value|
+  value.split(' ')
+end
+
+pipeline = source | splitter
+
+pipeline.shift #=> 'A'
+pipeline.shift #=> 'bold'
+pipeline.shift #=> 'move'
+pipeline.shift #=> 'westward'
+pipeline.shift #=> nil
+```
+
 ## Origins of Stepladder
 
 Stepladder grew out of experimentation with Ruby fibers, after readings
@@ -364,10 +388,7 @@ The Stepladder::Worker documentation has been moved
 
 ## Roadmap
 
-- `splitter_worker` -- would accept a value and return an array.  The
-  elements of that returned array would then be output as separate values
-  to the next worker in the pipeline.
-- `batch_worker trailing: n` -- accepts a value, and returns the last n
+- `rolling_worker trails: n` -- accepts a value, and returns the last n
   values.  This would mean that no values would be returned until n
   values had been accumulated.  This could be useful for things like
   rolling averages.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ for several common types of workers.  Let's look at them.
 But first, be sure to include the DSL mixin:
 
 ```ruby
-include Stepladder::Dsl
+include Stepladder::DSL
 ```
 
 ### Source Worker
@@ -350,7 +350,7 @@ Consider the following ~~code~~ vaporware:
 ```ruby
 SUBJECT = 'kitteh'
 
-include Stepladder::Dsl
+include Stepladder::DSL
 
 tweet_getter = source_worker do
   twitter_api.fetch_my_tweets

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ which to operate:
 ```ruby
 source = source_worker (0..3)
 
-squarer.supplier = source
+squarer.supply = source
 ```
 
 Or, if you prefer, the DSL provides a vertical pipe for linking the

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ string each time it is invoked:
 ```ruby
 worker = source_worker { "Number 9" }
 
-worker.product #=> "Number 9"
-worker.product #=> "Number 9"
-worker.product #=> "Number 9"
+worker.shift #=> "Number 9"
+worker.shift #=> "Number 9"
+worker.shift #=> "Number 9"
 # ...ad nauseum...
 ```
 
@@ -68,11 +68,11 @@ worker = source_worker do
   end
 end
 
-worker.product #=> 1001
-worker.product #=> 1002
-worker.product #=> 1003
-worker.product #=> nil
-worker.product #=> nil (and will be nil henceforth)
+worker.shift #=> 1001
+worker.shift #=> 1002
+worker.shift #=> 1003
+worker.shift #=> nil
+worker.shift #=> nil (and will be nil henceforth)
 ```
 
 If all you want is a source worker which generates a series of numbers
@@ -82,10 +82,10 @@ the DSL provides an easier way to do it:
 w1 = source_worker [0,1,2]
 w2 = source_worker (0..2)
 
-w1.product == w2.product #=> 0
-w1.product == w2.product #=> 1
-w1.product == w2.product #=> 2
-w1.product == w2.product #=> nil (and henceforth, etc.)
+w1.shift == w2.shift #=> 0
+w1.shift == w2.shift #=> 1
+w1.shift == w2.shift #=> 2
+w1.shift == w2.shift #=> nil (and henceforth, etc.)
 ```
 
 ### Relay Worker
@@ -114,11 +114,11 @@ workers together into a pipeline:
 ```ruby
 pipeline = source | squarer
 
-pipeline.product #=> 0
-pipeline.product #=> 1
-pipeline.product #=> 4
-pipeline.product #=> 9
-pipeline.product #=> nil
+pipeline.shift #=> 0
+pipeline.shift #=> 1
+pipeline.shift #=> 4
+pipeline.shift #=> 9
+pipeline.shift #=> nil
 ```
 
 ### Side Worker
@@ -143,11 +143,11 @@ end
 # re-using "squarer" from above example...
 pipeline = source | even_stasher | squarer
 
-pipeline.product #=> 0
-pipeline.product #=> 1
-pipeline.product #=> 4
-pipeline.product #=> 9
-pipeline.product #=> nil
+pipeline.shift #=> 0
+pipeline.shift #=> 1
+pipeline.shift #=> 4
+pipeline.shift #=> 9
+pipeline.shift #=> nil
 
 evens #=> [0, 2]
 ```
@@ -202,10 +202,10 @@ end
 
 pipeline = source | filter
 
-pipeline.product #=> 0
-pipeline.product #=> 2
-pipeline.product #=> 4
-pipeline.product #=> nil
+pipeline.shift #=> 0
+pipeline.shift #=> 2
+pipeline.shift #=> 4
+pipeline.shift #=> nil
 ```
 
 ### Batch Worker
@@ -220,10 +220,10 @@ batch = batch_worker gathering: 3
 
 pipeline = source | batch
 
-pipeline.product #=> [0, 1, 2]
-pipeline.product #=> [3, 4, 5]
-pipeline.product #=> [6, 7]
-pipeline.product #=> nil
+pipeline.shift #=> [0, 1, 2]
+pipeline.shift #=> [3, 4, 5]
+pipeline.shift #=> [6, 7]
+pipeline.shift #=> nil
 ```
 
 Notice how the final batch doesn't have full compliment of three.
@@ -243,9 +243,9 @@ end
 
 pipeline = source | line_reader
 
-pipeline.product #=> ["some", "rain", "must\n"]
-pipeline.product #=> ["fall", "but", "ok"]
-pipeline.product #=> nil
+pipeline.shift #=> ["some", "rain", "must\n"]
+pipeline.shift #=> ["fall", "but", "ok"]
+pipeline.shift #=> nil
 ```
 
 ## Origins of Stepladder
@@ -342,7 +342,7 @@ end
 
 kitteh_tweets = tweet_getter | about_me | tweet_formatter
 
-while tweet = kitteh_tweets.product
+while tweet = kitteh_tweets.shift
   display(tweet)
 end
 ```

--- a/docs/stepladder/worker.md
+++ b/docs/stepladder/worker.md
@@ -60,35 +60,12 @@ useless_worker = Stepladder::Worker.new(supply: source_worker)
 useless_worker.shift #=> 'hulk'
 ```
 
-This turns out to be helpful in implementing filter workers, which are up next.
-
-## Workers can have filters...
-
-Given a source worker which provides integers 1-3:
-
-```ruby
-source = Stepladder::Worker.new do
-  (1..3).each { |number| handoff number }
-end
-```
-
-...we can define a subscribing worker with a filter:
-
-```ruby
-odd_number_filter = Proc.new { |number| number % 2 > 0 }
-filter_worker = Stepladder::Worker.new filter: odd_number_filter
-
-filter_worker.shift #=> 1
-filter_worker.shift #=> 3
-filter_worker.shift #=> nil
-```
-
 ## The pipeline DSL
 
 You can stitch your workers together using the vertical pipe ("|") like so:
 
 ```ruby
-pipeline = source_worker | filter_worker | relay_worker | another worker
+pipeline = source_worker | relay_worker | another worker
 ```
 
 ...and then just call on that pipeline (it's actually the last worker in the

--- a/docs/stepladder/worker.md
+++ b/docs/stepladder/worker.md
@@ -9,7 +9,7 @@ Initialize with a block of code:
 ```ruby
 source_worker = Stepladder::Worker.new { "hulk" }
 
-source_worker.product #=> "hulk"
+source_worker.shift #=> "hulk"
 ```
 If you supply a worker with another worker as its supplier, then you
 can give it a task which accepts a value:
@@ -18,7 +18,7 @@ can give it a task which accepts a value:
 relay_worker = Stepladder::Worker.new { |name| name.upcase }
 relay_worker.supplier = source_worker
 
-relay_worker.product #=> "HULK"
+relay_worker.shift #=> "HULK"
 ```
 
 You can also initialize a worker by passing in a callable object
@@ -28,7 +28,7 @@ as its task:
 capitalizer = Proc.new { |name| name.capitalize }
 relay_worker = Stepladder::Worker.new(task: capitalizer, supplier: source_worker)
 
-relay_worker.product #=> 'Hulk'
+relay_worker.shift #=> 'Hulk'
 ```
 
 A worker also has an accessor for its @task:
@@ -37,7 +37,7 @@ A worker also has an accessor for its @task:
 doofusizer = Proc.new { |name| name.gsub(/u/, 'oo') }
 relay_worker.task = doofusizer
 
-relay_worker.product #=> 'hoolk'
+relay_worker.shift #=> 'hoolk'
 ```
 
 And finally, you can provide a task by directly overriding the
@@ -48,7 +48,7 @@ def relay_worker.task(name)
   name.to_sym
 end
 
-relay_worker.product #=> :hulk
+relay_worker.shift #=> :hulk
 ```
 
 Even workers without a task have a task; all workers actually come
@@ -57,7 +57,7 @@ with a default task which simply passes on the received value unchanged:
 ```ruby
 useless_worker = Stepladder::Worker.new(supplier: source_worker)
 
-useless_worker.product #=> 'hulk'
+useless_worker.shift #=> 'hulk'
 ```
 
 This turns out to be helpful in implementing filter workers, which are up next.
@@ -78,9 +78,9 @@ end
 odd_number_filter = Proc.new { |number| number % 2 > 0 }
 filter_worker = Stepladder::Worker.new filter: odd_number_filter
 
-filter_worker.product #=> 1
-filter_worker.product #=> 3
-filter_worker.product #=> nil
+filter_worker.shift #=> 1
+filter_worker.shift #=> 3
+filter_worker.shift #=> nil
 ```
 
 ## The pipeline DSL
@@ -95,7 +95,7 @@ pipeline = source_worker | filter_worker | relay_worker | another worker
 chain):
 
 ```ruby
-while next_value = pipeline.product do
+while next_value = pipeline.shift do
   do_something_with next_value
   # etc.
 end

--- a/docs/stepladder/worker.md
+++ b/docs/stepladder/worker.md
@@ -11,12 +11,12 @@ source_worker = Stepladder::Worker.new { "hulk" }
 
 source_worker.shift #=> "hulk"
 ```
-If you supply a worker with another worker as its supplier, then you
+If you supply a worker with another worker as its supply, then you
 can give it a task which accepts a value:
 
 ```ruby
 relay_worker = Stepladder::Worker.new { |name| name.upcase }
-relay_worker.supplier = source_worker
+relay_worker.supply = source_worker
 
 relay_worker.shift #=> "HULK"
 ```
@@ -26,7 +26,7 @@ as its task:
 
 ```ruby
 capitalizer = Proc.new { |name| name.capitalize }
-relay_worker = Stepladder::Worker.new(task: capitalizer, supplier: source_worker)
+relay_worker = Stepladder::Worker.new(task: capitalizer, supply: source_worker)
 
 relay_worker.shift #=> 'Hulk'
 ```
@@ -55,7 +55,7 @@ Even workers without a task have a task; all workers actually come
 with a default task which simply passes on the received value unchanged:
 
 ```ruby
-useless_worker = Stepladder::Worker.new(supplier: source_worker)
+useless_worker = Stepladder::Worker.new(supply: source_worker)
 
 useless_worker.shift #=> 'hulk'
 ```

--- a/lib/stepladder.rb
+++ b/lib/stepladder.rb
@@ -1,3 +1,4 @@
 require_relative 'stepladder/version'
 require_relative 'stepladder/worker'
+require_relative 'stepladder/gang'
 require_relative 'stepladder/dsl'

--- a/lib/stepladder.rb
+++ b/lib/stepladder.rb
@@ -1,4 +1,5 @@
 require_relative 'stepladder/version'
 require_relative 'stepladder/worker'
 require_relative 'stepladder/gang'
+require_relative 'stepladder/roster'
 require_relative 'stepladder/dsl'

--- a/lib/stepladder/dsl.rb
+++ b/lib/stepladder/dsl.rb
@@ -81,6 +81,22 @@ module Stepladder
       end
     end
 
+    def splitter_worker(&block)
+      ensure_regular_arity(block)
+
+      Worker.new do |value|
+        if value.nil?
+          value
+        else
+          parts = block.call(value)
+          while parts.size > 1 do
+            handoff parts.shift
+          end
+          parts.shift
+        end
+      end
+    end
+
     def handoff(something)
       Fiber.yield something
     end

--- a/lib/stepladder/dsl.rb
+++ b/lib/stepladder/dsl.rb
@@ -59,7 +59,7 @@ module Stepladder
           if value
             @collection = [value]
             until batch_complete?(@collection.last)
-              @collection << supplier.product
+              @collection << supplier.shift
             end
             @collection.compact
           end

--- a/lib/stepladder/dsl.rb
+++ b/lib/stepladder/dsl.rb
@@ -88,7 +88,7 @@ module Stepladder
         if value.nil?
           value
         else
-          parts = block.call(value)
+          parts = [block.call(value)].flatten
           while parts.size > 1 do
             handoff parts.shift
           end

--- a/lib/stepladder/dsl.rb
+++ b/lib/stepladder/dsl.rb
@@ -28,12 +28,15 @@ module Stepladder
       end
     end
 
-    def side_worker(&block)
+    def side_worker(mode=:normal, &block)
       ensure_regular_arity(block)
 
       Worker.new do |value|
         value.tap do |v|
-          v && block.call(v)
+          used_value = mode == :hardened ?
+            Marshal.load(Marshal.dump(v)) : v
+
+          v && block.call(used_value)
         end
       end
     end

--- a/lib/stepladder/dsl.rb
+++ b/lib/stepladder/dsl.rb
@@ -1,7 +1,7 @@
 module Stepladder
   class WorkerInitializationError < StandardError; end
 
-  module Dsl
+  module DSL
     def source_worker(argument=nil, &block)
       ensure_correct_arity_for!(argument, block)
 

--- a/lib/stepladder/dsl.rb
+++ b/lib/stepladder/dsl.rb
@@ -97,6 +97,25 @@ module Stepladder
       end
     end
 
+    def trailing_worker(trail_length=2)
+      trail = []
+      Worker.new do |value, supply|
+        if value
+          trail.unshift value
+          if trail.size >= trail_length
+            trail.pop
+          end
+          while trail.size < trail_length
+            trail.unshift supply.shift
+          end
+
+          trail
+        else
+          value
+        end
+      end
+    end
+
     def handoff(something)
       Fiber.yield something
     end

--- a/lib/stepladder/dsl.rb
+++ b/lib/stepladder/dsl.rb
@@ -59,7 +59,7 @@ module Stepladder
           if value
             @collection = [value]
             until batch_complete?(@collection.last)
-              @collection << supplier.shift
+              @collection << supply.shift
             end
             @collection.compact
           end

--- a/lib/stepladder/dsl.rb
+++ b/lib/stepladder/dsl.rb
@@ -43,9 +43,14 @@ module Stepladder
         throw_with 'You cannot supply two callables'
       end
       callable = argument.respond_to?(:call) ? argument : block
-
       ensure_callable(callable)
-      Worker.new filter: block
+
+      Worker.new do |value, supply|
+        while value && !callable.call(value) do
+          value = supply.shift
+        end
+        value
+      end
     end
 
     def batch_worker(options = {gathering: 1}, &block)

--- a/lib/stepladder/gang.rb
+++ b/lib/stepladder/gang.rb
@@ -1,3 +1,5 @@
+require 'stepladder/roster'
+
 module Stepladder
   class Gang
     attr_accessor :workers
@@ -31,36 +33,12 @@ module Stepladder
     end
     alias_method :"|", :supplies
 
-    def roster_push(worker)
-      if worker
-        worker.supply = @workers.last
-        @workers << worker
-      end
-    end
-    alias_method :"<<", :roster_push
-
-    def roster_pop
-      workers.pop.tap do |popped|
-        popped.supply = nil
-      end
-    end
-
-    def roster_shift
-      workers.shift.tap do
-        workers.first.supply = nil
-      end
-    end
-
-    def roster_unshift(worker)
-      workers.first.supply = worker
-      workers.unshift worker
-    end
     private
 
     def link(workers)
       @workers = [workers.shift]
       while worker = workers.shift do
-        self << worker
+        Roster[self] << worker
       end
     end
 

--- a/lib/stepladder/gang.rb
+++ b/lib/stepladder/gang.rb
@@ -1,0 +1,68 @@
+module Stepladder
+  class Gang
+    attr_accessor :workers
+
+    def initialize(workers=[])
+      link(workers + [])
+    end
+
+    def roster
+      workers
+    end
+
+    def shift
+      workers.last.shift
+    end
+
+    def ready_to_work?
+      workers.first.ready_to_work?
+    end
+
+    def supply
+      workers.first.supply
+    end
+
+    def supply=(source_queue)
+      workers.first.supply = source_queue
+    end
+
+    def supplies(subscribing_party)
+      subscribing_party.supply = self
+    end
+    alias_method :"|", :supplies
+
+    def roster_push(worker)
+      if worker
+        worker.supply = @workers.last
+        @workers << worker
+      end
+    end
+    alias_method :"<<", :roster_push
+
+    def roster_pop
+      workers.pop.tap do |popped|
+        popped.supply = nil
+      end
+    end
+
+    def roster_shift
+      workers.shift.tap do
+        workers.first.supply = nil
+      end
+    end
+
+    def roster_unshift(worker)
+      workers.first.supply = worker
+      workers.unshift worker
+    end
+    private
+
+    def link(workers)
+      @workers = [workers.shift]
+      while worker = workers.shift do
+        self << worker
+      end
+    end
+
+  end
+end

--- a/lib/stepladder/roster.rb
+++ b/lib/stepladder/roster.rb
@@ -1,0 +1,46 @@
+module Stepladder
+  module Roster
+    class << self
+      def [](gang)
+        RosterizedGang.new(gang)
+      end
+    end
+  end
+
+  class RosterizedGang
+    attr_reader :gang
+
+    def initialize(gang)
+      @gang = gang
+    end
+
+    def workers
+      gang.workers
+    end
+
+    def push(worker)
+      if worker
+        worker.supply = workers.last
+        workers << worker
+      end
+    end
+    alias_method :"<<", :push
+
+    def pop
+      gang.workers.pop.tap do |popped|
+        popped.supply = nil
+      end
+    end
+
+    def shift
+      workers.shift.tap do
+        workers.first.supply = nil
+      end
+    end
+
+    def unshift(worker)
+      workers.first.supply = worker
+      workers.unshift worker
+    end
+  end
+end

--- a/lib/stepladder/version.rb
+++ b/lib/stepladder/version.rb
@@ -1,3 +1,3 @@
 module Stepladder
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lib/stepladder/worker.rb
+++ b/lib/stepladder/worker.rb
@@ -6,7 +6,6 @@ module Stepladder
 
     def initialize(p={}, &block)
       @supply   = p[:supply]
-      @filter   = p[:filter] || default_filter
       @task     = block || p[:task]
       @context  = p[:context] || OpenStruct.new
       # don't define default task here
@@ -74,16 +73,6 @@ module Stepladder
 
     def task_method_accepts_a_value?
       self.method(:task).arity > 0
-    end
-
-    def default_filter
-      Proc.new do |value|
-        true
-      end
-    end
-
-    def passes_filter?(value)
-      @filter.call value
     end
 
   end

--- a/lib/stepladder/worker.rb
+++ b/lib/stepladder/worker.rb
@@ -1,11 +1,14 @@
+require 'ostruct'
+
 module Stepladder
   class Worker
     attr_accessor :supply
 
     def initialize(p={}, &block)
-      @supply = p[:supply]
+      @supply   = p[:supply]
       @filter   = p[:filter] || default_filter
       @task     = block || p[:task]
+      @context  = p[:context] || OpenStruct.new
       # don't define default task here
       # because we want to allow for
       # an initialized worker to have
@@ -44,7 +47,7 @@ module Stepladder
       @my_little_machine ||= Fiber.new do
         loop do
           value = supply && supply.shift
-          Fiber.yield @task.call(value, supply)
+          Fiber.yield @task.call(value, supply, @context)
         end
       end
     end

--- a/lib/stepladder/worker.rb
+++ b/lib/stepladder/worker.rb
@@ -1,9 +1,9 @@
 module Stepladder
   class Worker
-    attr_accessor :supplier
+    attr_accessor :supply
 
     def initialize(p={}, &block)
-      @supplier = p[:supplier]
+      @supply = p[:supply]
       @filter   = p[:filter] || default_filter
       @task     = block || p[:task]
       # don't define default task here
@@ -19,11 +19,11 @@ module Stepladder
     end
 
     def ready_to_work?
-      @task && (supplier || !task_accepts_a_value?)
+      @task && (supply || !task_accepts_a_value?)
     end
 
     def |(subscribing_worker)
-      subscribing_worker.supplier = self
+      subscribing_worker.supply = self
       subscribing_worker
     end
 
@@ -36,14 +36,14 @@ module Stepladder
       # asked for product
 
       unless ready_to_work?
-        raise "This worker's task expects to receive a value from a supplier, but has no supplier."
+        raise "This worker's task expects to receive a value from a supplier, but has no supply."
       end
     end
 
     def workflow
       @my_little_machine ||= Fiber.new do
         loop do
-          value = supplier && supplier.shift
+          value = supply && supply.shift
           if value.nil? || passes_filter?(value)
             Fiber.yield @task.call(value)
           end
@@ -58,7 +58,7 @@ module Stepladder
         else
           Proc.new { self.task }
         end
-      else # no task method, so assuming we have supplier...
+      else # no task method, so assuming we have supply...
         Proc.new { |value| value }
       end
     end

--- a/lib/stepladder/worker.rb
+++ b/lib/stepladder/worker.rb
@@ -13,7 +13,7 @@ module Stepladder
       # method-based tasks.
     end
 
-    def product
+    def shift
       ensure_ready_to_work!
       workflow.resume
     end
@@ -43,7 +43,7 @@ module Stepladder
     def workflow
       @my_little_machine ||= Fiber.new do
         loop do
-          value = supplier && supplier.product
+          value = supplier && supplier.shift
           if value.nil? || passes_filter?(value)
             Fiber.yield @task.call(value)
           end

--- a/lib/stepladder/worker.rb
+++ b/lib/stepladder/worker.rb
@@ -44,9 +44,7 @@ module Stepladder
       @my_little_machine ||= Fiber.new do
         loop do
           value = supply && supply.shift
-          if value.nil? || passes_filter?(value)
-            Fiber.yield @task.call(value)
-          end
+          Fiber.yield @task.call(value, supply)
         end
       end
     end

--- a/spec/lib/stepladder/dsl_spec.rb
+++ b/spec/lib/stepladder/dsl_spec.rb
@@ -251,7 +251,6 @@ module Stepladder
     end
 
     context '#splitter_worker' do
-
       context 'normal usage' do
         Given(:source) { source_worker ['A bold', 'move northward'] }
         Given(:worker) do
@@ -269,7 +268,30 @@ module Stepladder
         And  { worker.shift.nil? }
       end
 
+      context 'always returns an array' do
+        Given(:source) { source_worker [:foo] }
+        Given(:worker) do
+          splitter_worker { |value| value }
+        end
+
+        When { source | worker }
+
+        Then { worker.shift == :foo }
+        And  { worker.shift == nil }
+      end
+
       context 'illegal usage' do
+        context 'requires a callable' do
+          context 'with arity == 0' do
+            Given(:invocation) { -> { splitter_worker() { [] } } }
+            Then { expect(invocation).to raise_error(/arity == 1/) }
+          end
+
+          context 'with arity > 1' do
+            Given(:invocation) { -> { splitter_worker() { |a,b| [] } } }
+            Then { expect(invocation).to raise_error(/arity == 1/) }
+          end
+        end
 
       end
     end

--- a/spec/lib/stepladder/dsl_spec.rb
+++ b/spec/lib/stepladder/dsl_spec.rb
@@ -9,42 +9,42 @@ module Stepladder
         context 'with an array' do
           Given(:worker) { source_worker [:fee, :fi] }
 
-          Then { worker.product == :fee }
-          And  { worker.product == :fi }
-          And  { worker.product.nil? }
+          Then { worker.shift == :fee }
+          And  { worker.shift == :fi }
+          And  { worker.shift.nil? }
         end
 
         context 'with a range' do
           Given(:worker) { source_worker (0..2) }
 
-          Then { worker.product == 0 }
-          And  { worker.product == 1 }
-          And  { worker.product == 2 }
-          And  { worker.product.nil? }
+          Then { worker.shift == 0 }
+          And  { worker.shift == 1 }
+          And  { worker.shift == 2 }
+          And  { worker.shift.nil? }
         end
 
         context 'with a string' do
           Given(:worker) { source_worker 'abc' }
 
-          Then { worker.product == 'a' }
-          And  { worker.product == 'b' }
-          And  { worker.product == 'c' }
-          And  { worker.product.nil? }
+          Then { worker.shift == 'a' }
+          And  { worker.shift == 'b' }
+          And  { worker.shift == 'c' }
+          And  { worker.shift.nil? }
         end
 
         context 'with a hash' do
           Given(:worker) { source_worker({foo: 2, bar: 'yarr'}) }
 
-          Then { worker.product == [:foo, 2] }
-          And  { worker.product == [:bar, 'yarr'] }
-          And  { worker.product.nil? }
+          Then { worker.shift == [:foo, 2] }
+          And  { worker.shift == [:bar, 'yarr'] }
+          And  { worker.shift.nil? }
         end
 
         context 'with a anything else' do
           Given(:worker) { source_worker :foo }
 
-          Then { worker.product == :foo }
-          And  { worker.product.nil? }
+          Then { worker.shift == :foo }
+          And  { worker.shift.nil? }
         end
 
         context 'with a callable' do
@@ -55,10 +55,10 @@ module Stepladder
             end
           end
 
-          Then { worker.product == :doh }
-          And  { worker.product == :ray }
-          And  { worker.product == :me }
-          And  { worker.product.nil? }
+          Then { worker.shift == :doh }
+          And  { worker.shift == :ray }
+          And  { worker.shift == :me }
+          And  { worker.shift.nil? }
         end
 
         context 'with a callable and an argument' do
@@ -69,10 +69,10 @@ module Stepladder
             end
           end
 
-          Then { worker.product == 'SO' }
-          And  { worker.product == 'LA' }
-          And  { worker.product == 'TI' }
-          And  { worker.product.nil? }
+          Then { worker.shift == 'SO' }
+          And  { worker.shift == 'LA' }
+          And  { worker.shift == 'TI' }
+          And  { worker.shift.nil? }
         end
       end
 
@@ -110,10 +110,10 @@ module Stepladder
 
         When { source | relay }
 
-        Then { relay.product == 'be++er' }
-        And  { relay.product == 's+ronger' }
-        And  { relay.product == 'fas+er' }
-        And  { relay.product.nil? }
+        Then { relay.shift == 'be++er' }
+        And  { relay.shift == 's+ronger' }
+        And  { relay.shift == 'fas+er' }
+        And  { relay.shift.nil? }
       end
 
       context 'illegal usage' do
@@ -138,10 +138,10 @@ module Stepladder
 
         When { source | worker }
 
-        Then { worker.product == 0 }
-        And  { worker.product == 1 }
-        And  { worker.product == 2 }
-        And  { worker.product.nil? }
+        Then { worker.shift == 0 }
+        And  { worker.shift == 1 }
+        And  { worker.shift == 2 }
+        And  { worker.shift.nil? }
         And  { side_effect == [0, 2, 4] }
       end
 
@@ -166,8 +166,8 @@ module Stepladder
            filter_worker { |v| v % 2 == 0 }
         end
 
-        Then { filter.product == 2 }
-        And { expect(filter.product).to be_nil }
+        Then { filter.shift == 2 }
+        And { expect(filter.shift).to be_nil }
       end
 
       context 'illegal usage' do
@@ -208,19 +208,19 @@ module Stepladder
             batch_worker gathering: 3
           end
 
-          Then { worker.product == [ 0, 1, 2 ] }
-          And  { worker.product == [ 3, 4, 5 ] }
-          And  { worker.product == [ 6, 7 ] }
-          And  { worker.product.nil? }
+          Then { worker.shift == [ 0, 1, 2 ] }
+          And  { worker.shift == [ 3, 4, 5 ] }
+          And  { worker.shift == [ 6, 7 ] }
+          And  { worker.shift.nil? }
         end
 
         context 'defaults to batch size of 1' do
           Given(:source) { source_worker [8,9] }
           Given(:worker) { batch_worker }
 
-          Then { worker.product == [ 8 ] }
-          And  { worker.product == [ 9 ] }
-          And  { worker.product.nil? }
+          Then { worker.shift == [ 8 ] }
+          And  { worker.shift == [ 9 ] }
+          And  { worker.shift.nil? }
         end
 
         context 'collects until condition' do
@@ -229,10 +229,10 @@ module Stepladder
             batch_worker { |n| n % 2 == 0 }
           end
 
-          Then { worker.product == [ 1, 2 ] }
-          And  { worker.product == [ 3, 4 ] }
-          And  { worker.product == [ 5 ] }
-          And  { worker.product.nil? }
+          Then { worker.shift == [ 1, 2 ] }
+          And  { worker.shift == [ 3, 4 ] }
+          And  { worker.shift == [ 5 ] }
+          And  { worker.shift.nil? }
         end
       end
 

--- a/spec/lib/stepladder/dsl_spec.rb
+++ b/spec/lib/stepladder/dsl_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 module Stepladder
-  describe Dsl do
-    include Stepladder::Dsl
+  describe DSL do
+    include described_class
 
     describe '#source_worker' do
       context 'normal usage' do

--- a/spec/lib/stepladder/dsl_spec.rb
+++ b/spec/lib/stepladder/dsl_spec.rb
@@ -145,6 +145,34 @@ module Stepladder
         And  { side_effect == [0, 2, 4] }
       end
 
+      context 'mode' do
+        Given(:source) { source_worker [[:foo], [:bar]] }
+        Given(:unsafe_task) { Proc.new {|v| v << :boo } }
+
+        When { source | worker }
+
+        context ':normal (default)' do
+          Given(:worker) do
+            side_worker(&unsafe_task)
+          end
+
+          Then { worker.shift == [:foo, :boo] }
+          And  { worker.shift == [:bar, :boo] }
+          And  { worker.shift.nil? }
+
+        end
+
+        context ':hardened' do
+          Given(:worker) do
+            side_worker :hardened, &unsafe_task
+          end
+
+          Then { worker.shift == [:foo] }
+          And  { worker.shift == [:bar] }
+          And  { worker.shift.nil? }
+        end
+      end
+
       context 'illegal usage' do
         context 'arity == 0' do
           Given(:invocation) do

--- a/spec/lib/stepladder/dsl_spec.rb
+++ b/spec/lib/stepladder/dsl_spec.rb
@@ -198,12 +198,11 @@ module Stepladder
     end
 
     describe '#batch_worker' do
-      Given(:source) { source_worker (0..7) }
-
       context 'normal usage' do
         When { source | worker }
 
         context 'with specified "gathering" batch size' do
+          Given(:source) { source_worker (0..7) }
           Given(:worker) do
             batch_worker gathering: 3
           end

--- a/spec/lib/stepladder/dsl_spec.rb
+++ b/spec/lib/stepladder/dsl_spec.rb
@@ -292,7 +292,32 @@ module Stepladder
             Then { expect(invocation).to raise_error(/arity == 1/) }
           end
         end
+      end
+    end
 
+    context '#trailing_worker' do
+      context 'normal usage' do
+        Given(:source) { source_worker (0..5) }
+        Given(:worker) { trailing_worker 4 }
+
+        When { source | worker }
+
+        Then { worker.shift == [3,2,1,0] }
+        And  { worker.shift == [4,3,2,1] }
+        And  { worker.shift == [5,4,3,2] }
+        And  { worker.shift.nil? }
+      end
+
+      context 'default trail size' do
+        Given(:source) { source_worker (0..3) }
+        Given(:worker) { trailing_worker }
+
+        When { source | worker }
+
+        Then { worker.shift == [1,0] }
+        And  { worker.shift == [2,1] }
+        And  { worker.shift == [3,2] }
+        And  { worker.shift.nil? }
       end
     end
 

--- a/spec/lib/stepladder/dsl_spec.rb
+++ b/spec/lib/stepladder/dsl_spec.rb
@@ -246,8 +246,31 @@ module Stepladder
             Given(:invocation) { -> { batch_worker() { |a,b| :foo } } }
             Then { expect(invocation).to raise_error(/arity == 1/) }
           end
-
         end
+      end
+    end
+
+    context '#splitter_worker' do
+
+      context 'normal usage' do
+        Given(:source) { source_worker ['A bold', 'move northward'] }
+        Given(:worker) do
+          splitter_worker do |value|
+            value.split(' ')
+          end
+        end
+
+        When { source | worker }
+
+        Then { worker.shift == 'A' }
+        And  { worker.shift == 'bold' }
+        And  { worker.shift == 'move' }
+        And  { worker.shift == 'northward' }
+        And  { worker.shift.nil? }
+      end
+
+      context 'illegal usage' do
+
       end
     end
 

--- a/spec/lib/stepladder/gang_spec.rb
+++ b/spec/lib/stepladder/gang_spec.rb
@@ -1,0 +1,133 @@
+require 'spec_helper'
+
+module Stepladder
+  describe Gang do
+    include DSL
+
+    Given(:source) { source_worker (:a..:z).map(&:to_s) }
+    Given(:plusser) { relay_worker { |v| v + '+' } }
+    Given(:tilda_er) { relay_worker { |v| v + '~' } }
+
+    When(:gang) { described_class.new workers }
+
+    context 'covers Worker API' do
+      it do should respond_to :ready_to_work?, :shift,
+                              :supply, :supply=,
+                              :supplies, :"|",
+                              :roster_pop,
+                              :roster_push, :"<<",
+                              :roster_shift
+      end
+    end
+
+    describe '#ready_to_work?' do
+      context 'with no source' do
+        Given(:workers) { [plusser, tilda_er] }
+
+        Then { expect(gang).to_not be_ready_to_work }
+      end
+
+      context 'with an internal source' do
+        Given(:workers) { [source, plusser, tilda_er] }
+
+        Then { expect(gang).to be_ready_to_work }
+      end
+
+      context 'with external source' do
+        context 'supplied to the first worker' do
+          Given { source | plusser }
+          Given(:workers) { [plusser, tilda_er] }
+
+          Then { expect(gang).to be_ready_to_work }
+        end
+
+        context 'supplied to the gang' do
+          Given(:workers) { [plusser, tilda_er] }
+
+          When { gang.supply = source }
+
+          Then { expect(gang).to be_ready_to_work }
+        end
+      end
+    end
+
+    describe '#<< (a.k.a. #workers_push)' do
+      Given(:workers) { [source, plusser] }
+
+      When { gang << tilda_er }
+
+      Then { gang.shift == 'a+~' }
+    end
+
+    describe '#| (a.k.a. #supplies)' do
+      Given(:workers) { [source, plusser] }
+
+      When { gang | tilda_er }
+
+      context 'gets gang as source' do
+        Then { tilda_er.shift == 'a+~' }
+      end
+
+      context 'still works even if rearranging workers' do
+        Given(:minuser) { relay_worker { |v| v + '-' } }
+
+        When { gang << minuser }
+
+        Then { tilda_er.shift == 'a+-~' }
+      end
+    end
+
+    describe '#roster_pop' do
+      Given(:workers) { [source, plusser, tilda_er] }
+
+      When(:popped) { gang.roster_pop }
+
+      Then { gang.shift == 'a+' }
+      Then { popped == tilda_er }
+      Then { popped.supply.nil? }
+    end
+
+    describe '#roster_shift' do
+      Given(:workers) { [source, plusser, tilda_er] }
+
+      When(:shifted) { gang.roster_shift }
+
+      Then { shifted == source }
+      Then { expect(gang).to_not be_ready_to_work }
+    end
+
+    describe '#roster_unshift' do
+      context 'when first work is not a source' do
+        Given(:workers) { [plusser, tilda_er] }
+
+        When { gang.roster_unshift source }
+
+        Then { expect(gang).to be_ready_to_work }
+        Then { gang.roster == [source, plusser, tilda_er] }
+        Then { gang.shift == 'a+~' }
+      end
+
+      context 'when first worker is a source' do
+        Given(:new_source) { source_worker (:z..:a).map(&:to_s) }
+        Given(:workers) { [source, plusser, tilda_er] }
+
+        Then { expect { gang.roster_unshift new_source }.to raise_error(/cannot accept a supply/) }
+      end
+    end
+
+    describe '#roster' do
+      Given(:workers) { [source, plusser, tilda_er] }
+
+      Then { gang.roster == workers }
+    end
+
+    context 'normal usage' do
+      Given(:workers) { [source, plusser, tilda_er] }
+
+      Then { gang.shift == 'a+~' }
+    end
+
+
+  end
+end
+

--- a/spec/lib/stepladder/gang_spec.rb
+++ b/spec/lib/stepladder/gang_spec.rb
@@ -13,10 +13,7 @@ module Stepladder
     context 'covers Worker API' do
       it do should respond_to :ready_to_work?, :shift,
                               :supply, :supply=,
-                              :supplies, :"|",
-                              :roster_pop,
-                              :roster_push, :"<<",
-                              :roster_shift
+                              :supplies, :"|"
       end
     end
 
@@ -51,14 +48,6 @@ module Stepladder
       end
     end
 
-    describe '#<< (a.k.a. #workers_push)' do
-      Given(:workers) { [source, plusser] }
-
-      When { gang << tilda_er }
-
-      Then { gang.shift == 'a+~' }
-    end
-
     describe '#| (a.k.a. #supplies)' do
       Given(:workers) { [source, plusser] }
 
@@ -71,47 +60,9 @@ module Stepladder
       context 'still works even if rearranging workers' do
         Given(:minuser) { relay_worker { |v| v + '-' } }
 
-        When { gang << minuser }
+        When { Roster[gang].push minuser }
 
         Then { tilda_er.shift == 'a+-~' }
-      end
-    end
-
-    describe '#roster_pop' do
-      Given(:workers) { [source, plusser, tilda_er] }
-
-      When(:popped) { gang.roster_pop }
-
-      Then { gang.shift == 'a+' }
-      Then { popped == tilda_er }
-      Then { popped.supply.nil? }
-    end
-
-    describe '#roster_shift' do
-      Given(:workers) { [source, plusser, tilda_er] }
-
-      When(:shifted) { gang.roster_shift }
-
-      Then { shifted == source }
-      Then { expect(gang).to_not be_ready_to_work }
-    end
-
-    describe '#roster_unshift' do
-      context 'when first work is not a source' do
-        Given(:workers) { [plusser, tilda_er] }
-
-        When { gang.roster_unshift source }
-
-        Then { expect(gang).to be_ready_to_work }
-        Then { gang.roster == [source, plusser, tilda_er] }
-        Then { gang.shift == 'a+~' }
-      end
-
-      context 'when first worker is a source' do
-        Given(:new_source) { source_worker (:z..:a).map(&:to_s) }
-        Given(:workers) { [source, plusser, tilda_er] }
-
-        Then { expect { gang.roster_unshift new_source }.to raise_error(/cannot accept a supply/) }
       end
     end
 

--- a/spec/lib/stepladder/roster_spec.rb
+++ b/spec/lib/stepladder/roster_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+module Stepladder
+  describe Roster do
+    include DSL
+
+    Given(:source) { source_worker (:a..:z).map(&:to_s) }
+    Given(:plusser) { relay_worker { |v| v + '+' } }
+    Given(:tilda_er) { relay_worker { |v| v + '~' } }
+
+    Given(:gang) { Gang.new workers }
+
+    When(:roster) { described_class[gang] }
+
+    describe '#responds_to?' do
+      Given(:workers) { [] }
+      Then { roster.should respond_to :push, :pop, :shift, :unshift }
+    end
+
+    describe '#push' do
+      Given(:workers) { [source, plusser] }
+
+      When { roster.push tilda_er }
+
+      Then { gang.shift == 'a+~' }
+    end
+
+    describe '#pop' do
+      Given(:workers) { [source, plusser, tilda_er] }
+
+      When(:popped) { roster.pop }
+
+      Then { gang.shift == 'a+' }
+      Then { popped == tilda_er }
+      Then { popped.supply.nil? }
+    end
+
+    describe '#shift' do
+      Given(:workers) { [source, plusser, tilda_er] }
+
+      When(:shifted) { roster.shift }
+
+      Then { shifted == source }
+      Then { expect(gang).to_not be_ready_to_work }
+    end
+
+    describe '#unshift' do
+      context 'when first work is not a source' do
+        Given(:workers) { [plusser, tilda_er] }
+
+        When { roster.unshift source }
+
+        Then { expect(gang).to be_ready_to_work }
+        Then { gang.roster == [source, plusser, tilda_er] }
+        Then { gang.shift == 'a+~' }
+      end
+
+      context 'when first worker is a source' do
+        Given(:new_source) { source_worker (:z..:a).map(&:to_s) }
+        Given(:workers) { [source, plusser, tilda_er] }
+
+        Then { expect { roster.unshift new_source }.to raise_error(/cannot accept a supply/) }
+      end
+    end
+
+
+  end
+end

--- a/spec/lib/stepladder/worker_spec.rb
+++ b/spec/lib/stepladder/worker_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Stepladder
   describe Worker do
-    it { should respond_to(:product, :supplier, :supplier=, :"|") }
+    it { should respond_to(:shift, :supplier, :supplier=, :"|") }
 
     describe "readiness" do
       context "with no supplier" do
@@ -60,7 +60,7 @@ module Stepladder
             end
           end
 
-          its(:product) { should be_copasetic }
+          its(:shift) { should be_copasetic }
         end
 
         context "as {:task => <proc/lambda>} passed to ::new" do
@@ -70,7 +70,7 @@ module Stepladder
             Worker.new task: callable_task
           end
 
-          its(:product) { should be_copasetic }
+          its(:shift) { should be_copasetic }
         end
       end
 
@@ -84,13 +84,13 @@ module Stepladder
         context "which accepts an argument" do
           let(:supplier) { double }
           before do
-            supplier.stub(:product).and_return(result)
+            supplier.stub(:shift).and_return(result)
             subject.supplier = supplier
             def subject.task(value)
               Fiber.yield value
             end
           end
-          its(:product) { should be_copasetic }
+          its(:shift) { should be_copasetic }
         end
 
         context "or even one which accepts no arguments" do
@@ -99,15 +99,15 @@ module Stepladder
               :copasetic
             end
           end
-          its(:product) { should be :copasetic }
+          its(:shift) { should be :copasetic }
         end
       end
 
       context "However, when a worker's task accepts an argument," do
         context "but the worker has no supplier," do
           subject { Worker.new { |value| value.do_whatnot } }
-          specify "#product throws an exception" do
-            expect { subject.product }.to raise_error(/has no supplier/)
+          specify "#shift throws an exception" do
+            expect { subject.shift }.to raise_error(/has no supplier/)
           end
         end
       end
@@ -146,11 +146,11 @@ module Stepladder
       describe "The Source Worker" do
         subject(:the_self_starter) { source_worker }
 
-        it "generates products without a supplier." do
-          the_self_starter.product.should == 1
-          the_self_starter.product.should == 2
-          the_self_starter.product.should == 3
-          the_self_starter.product.should be_nil
+        it "generates values without a supplier." do
+          the_self_starter.shift.should == 1
+          the_self_starter.shift.should == 2
+          the_self_starter.shift.should == 3
+          the_self_starter.shift.should be_nil
         end
       end
 
@@ -162,10 +162,10 @@ module Stepladder
         subject(:triplizer) { relay_worker }
 
         it "operates on values received from its supplier." do
-          triplizer.product.should == 3
-          triplizer.product.should == 6
-          triplizer.product.should == 9
-          triplizer.product.should be_nil
+          triplizer.shift.should == 3
+          triplizer.shift.should == 6
+          triplizer.shift.should == 9
+          triplizer.shift.should be_nil
         end
       end
 
@@ -177,9 +177,9 @@ module Stepladder
         subject(:oddball) { filter_worker }
 
         it "passes through only select values." do
-          oddball.product.should == 1
-          oddball.product.should == 3
-          oddball.product.should be_nil
+          oddball.shift.should == 1
+          oddball.shift.should == 3
+          oddball.shift.should be_nil
         end
       end
 
@@ -189,7 +189,7 @@ module Stepladder
             if value
               @collection = [value]
               while @collection.size < 3
-                @collection << supplier.product
+                @collection << supplier.shift
               end
               @collection
             end
@@ -201,8 +201,8 @@ module Stepladder
         subject(:collector) { collector_worker }
 
         it "collects values in threes" do
-          collector.product.should == [1,2,3]
-          collector.product.should be_nil
+          collector.shift.should == [1,2,3]
+          collector.shift.should be_nil
         end
       end
 
@@ -215,20 +215,20 @@ module Stepladder
       When(:pipeline) { source_worker | subscribing_worker }
 
       Then { subscribing_worker.supplier == source_worker }
-      Then { pipeline.product == :foo_bar }
+      Then { pipeline.shift == :foo_bar }
       Then { pipeline == subscribing_worker }
     end
 
-    describe "#product" do
+    describe "#shift" do
       Given(:work_product) { :whatever }
-      Given { supplier.stub(:product).and_return(work_product) }
+      Given { supplier.stub(:shift).and_return(work_product) }
       Given { subject.supplier = supplier }
       Given(:supplier) { double }
 
       context "resumes a fiber" do
         Given { Fiber.any_instance.should_receive(:resume).and_return(work_product) }
 
-        Then { subject.product }
+        Then { subject.shift }
       end
     end
 

--- a/spec/lib/stepladder/worker_spec.rb
+++ b/spec/lib/stepladder/worker_spec.rb
@@ -131,8 +131,6 @@ module Stepladder
         end
       end
 
-      let(:collector_worker) { Worker.new }
-
       describe "The Source Worker" do
         subject(:the_self_starter) { source_worker }
 
@@ -158,30 +156,6 @@ module Stepladder
           triplizer.shift.should be_nil
         end
       end
-
-      describe "The Collector" do
-        before do
-          def collector_worker.task(value)
-            if value
-              @collection = [value]
-              while @collection.size < 3
-                @collection << supply.shift
-              end
-              @collection
-            end
-          end
-
-          collector_worker.supply = source_worker
-        end
-
-        subject(:collector) { collector_worker }
-
-        it "collects values in threes" do
-          collector.shift.should == [1,2,3]
-          collector.shift.should be_nil
-        end
-      end
-
     end
 
     describe "#|" do

--- a/spec/lib/stepladder/worker_spec.rb
+++ b/spec/lib/stepladder/worker_spec.rb
@@ -131,16 +131,6 @@ module Stepladder
         end
       end
 
-      let(:filter) do
-        Proc.new do |number|
-          number % 2 > 0
-        end
-      end
-
-      let(:filter_worker) do
-        Worker.new filter: filter
-      end
-
       let(:collector_worker) { Worker.new }
 
       describe "The Source Worker" do
@@ -166,20 +156,6 @@ module Stepladder
           triplizer.shift.should == 6
           triplizer.shift.should == 9
           triplizer.shift.should be_nil
-        end
-      end
-
-      describe "The Filter" do
-        before do
-          filter_worker.supply = source_worker
-        end
-
-        subject(:oddball) { filter_worker }
-
-        it "passes through only select values." do
-          oddball.shift.should == 1
-          oddball.shift.should == 3
-          oddball.shift.should be_nil
         end
       end
 

--- a/spec/lib/stepladder/worker_spec.rb
+++ b/spec/lib/stepladder/worker_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 module Stepladder
   describe Worker do
-    it { should respond_to(:shift, :supplier, :supplier=, :"|") }
+    it { should respond_to(:shift, :supply, :supply=, :"|") }
 
     describe "readiness" do
-      context "with no supplier" do
+      context "with no supply" do
         context "with no task" do
           it { should_not be_ready_to_work }
         end
@@ -23,9 +23,9 @@ module Stepladder
         end
       end
 
-      context "with a supplier" do
+      context "with a supply" do
         before do
-          subject.supplier = Worker.new { "foofoo" }
+          subject.supply = Worker.new { "foofoo" }
         end
         context "with no task" do
           it { should_not be_ready_to_work }
@@ -82,10 +82,10 @@ module Stepladder
         subject { Worker.new }
 
         context "which accepts an argument" do
-          let(:supplier) { double }
+          let(:supply) { double }
           before do
-            supplier.stub(:shift).and_return(result)
-            subject.supplier = supplier
+            supply.stub(:shift).and_return(result)
+            subject.supply = supply
             def subject.task(value)
               Fiber.yield value
             end
@@ -104,10 +104,10 @@ module Stepladder
       end
 
       context "However, when a worker's task accepts an argument," do
-        context "but the worker has no supplier," do
+        context "but the worker has no supply," do
           subject { Worker.new { |value| value.do_whatnot } }
           specify "#shift throws an exception" do
-            expect { subject.shift }.to raise_error(/has no supplier/)
+            expect { subject.shift }.to raise_error(/has no supply/)
           end
         end
       end
@@ -146,7 +146,7 @@ module Stepladder
       describe "The Source Worker" do
         subject(:the_self_starter) { source_worker }
 
-        it "generates values without a supplier." do
+        it "generates values without a supply." do
           the_self_starter.shift.should == 1
           the_self_starter.shift.should == 2
           the_self_starter.shift.should == 3
@@ -156,12 +156,12 @@ module Stepladder
 
       describe "The Relay Worker" do
         before do
-          relay_worker.supplier = source_worker
+          relay_worker.supply = source_worker
         end
 
         subject(:triplizer) { relay_worker }
 
-        it "operates on values received from its supplier." do
+        it "operates on values received from its supply." do
           triplizer.shift.should == 3
           triplizer.shift.should == 6
           triplizer.shift.should == 9
@@ -171,7 +171,7 @@ module Stepladder
 
       describe "The Filter" do
         before do
-          filter_worker.supplier = source_worker
+          filter_worker.supply = source_worker
         end
 
         subject(:oddball) { filter_worker }
@@ -189,13 +189,13 @@ module Stepladder
             if value
               @collection = [value]
               while @collection.size < 3
-                @collection << supplier.shift
+                @collection << supply.shift
               end
               @collection
             end
           end
 
-          collector_worker.supplier = source_worker
+          collector_worker.supply = source_worker
         end
 
         subject(:collector) { collector_worker }
@@ -214,16 +214,16 @@ module Stepladder
 
       When(:pipeline) { source_worker | subscribing_worker }
 
-      Then { subscribing_worker.supplier == source_worker }
+      Then { subscribing_worker.supply == source_worker }
       Then { pipeline.shift == :foo_bar }
       Then { pipeline == subscribing_worker }
     end
 
     describe "#shift" do
       Given(:work_product) { :whatever }
-      Given { supplier.stub(:shift).and_return(work_product) }
-      Given { subject.supplier = supplier }
-      Given(:supplier) { double }
+      Given { supply.stub(:shift).and_return(work_product) }
+      Given { subject.supply = supply }
+      Given(:supply) { double }
 
       context "resumes a fiber" do
         Given { Fiber.any_instance.should_receive(:resume).and_return(work_product) }


### PR DESCRIPTION
This is a fairly deep, seriously breaking change.  It renames `worker.product` to `worker.shift` in order to align with the abstraction of a FIFO queue or array which provides a `.shift` method.  Additionally, the `#supplier` is now just called `#supply` (as in “a supply of products”) so that it is possible to pull additional values from the supplying worker (queue) with `supply.shift`.

Accordingly, there are two new parameters which are passed to every worker callable, namely `supply` and `context`.  The latter is, by default, an empty OpenStruct instance, but could be provided to `Worker.new(context: object)` as literally any kind of object.  How the worker uses it is up to the worker.  The context persists and survives from one shift to the next.  (I predict that context will likely be abused).

This PR also adds a ‘splitter_worker’ to the DSL, and adds specs for the new `supply` and `context` parameters which are passed to workers’ procs.